### PR TITLE
remove deprecated addTranslation method

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -526,7 +526,7 @@ export default Ember.Component.extend(ClusterDriver, {
     const translation = languages[lang] || languages['en-us'];
     const intl = get(this, 'intl');
 
-    intl.addTranslation(lang, 'clusterNew.oke', translation.clusterNew.oke);
+    intl.addTranslations(lang, translation);
     intl.translationsFor(lang);
     set(this, 'refresh', false);
     next(() => {


### PR DESCRIPTION
I was asked to give a quick review on the UI PR you had open yesterday. It looks like that was merged overnight so I figured I would add this PR to update the addTranslation method since we are now using ember-intl v4 which moved to a new method for adding translations. This method was available in the 2.x ember-intl branch so it should be backwards compatible if the driver is used on a version of rancher < 2.3.3.